### PR TITLE
Version 1.4.0

### DIFF
--- a/Hermes/Logic/StrHandler.cs
+++ b/Hermes/Logic/StrHandler.cs
@@ -87,6 +87,8 @@ namespace Hermes.Logic
                 "traditionalchinese"
             };
 
+            bool shouldOverrideFile = false;
+
             foreach (string lang in languages)
             {
                 string langPath, combinedPath;
@@ -105,9 +107,10 @@ namespace Hermes.Logic
                 Directory.CreateDirectory(langPath);
                 string strFile = Path.Combine(langPath, file);
 
-                if (File.Exists(strFile))
+                if (!shouldOverrideFile && File.Exists(strFile))
                 {
-                    continue;
+                    shouldOverrideFile = true;
+                    CLI.WaitForUserConfirmation("File already exists. Press any key to continue. This will override any existing .str file");
                 }
 
                 WriteNewStrFile(file, langPath, lang); // Potentially always write a new file anyways to replace it with the proper language

--- a/Hermes/Program.cs
+++ b/Hermes/Program.cs
@@ -13,7 +13,7 @@ namespace Hermes
         {
             Console.WriteLine("---------------------------------------------------------------------------------------------------");
             Console.WriteLine(" Hermes, a drag and drop tool for BO3 to automatically support all languages for localized strings. ");
-            Console.WriteLine(" Version: 1.3.1");
+            Console.WriteLine(" Version: 1.4.0");
             Console.WriteLine("---------------------------------------------------------------------------------------------------");
             Console.WriteLine("");
 

--- a/Hermes/Utility/CLI.cs
+++ b/Hermes/Utility/CLI.cs
@@ -27,11 +27,11 @@ namespace Hermes.Utility
         public static void NoticeMessage(string message) => ColouredPrint(ConsoleColor.Yellow, message);
 
         /// <summary>
-        /// Waits for the user to input a key to exit the program
+        /// Waits for the user to input a key to continue
         /// </summary>
-        public static void WaitForUserConfirmation()
+        public static void WaitForUserConfirmation(string message = "Press any key to exit.")
         {
-            NeutralMessage("Press any key to exit.");
+            NoticeMessage(message);
             Console.ReadKey();
         }
     }


### PR DESCRIPTION
Support for overriding existing files upon user confirmation

Upon using your tool I noticed how it "stopped working" after its first use because it would unexpectedly ignore any existing file when I frequently make changes to my str file and I want to reflect these changes to all languages.

I kept it safe by asking for user confirmation (only once per file dragged onto the CLI, not for every single str file since it would be redundant)